### PR TITLE
review changes

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/op/Implicits.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/Implicits.scala
@@ -11,8 +11,7 @@ trait Implicits {
     extends CombineMethods[K, V]
 
   implicit class withCombineTraversableMethods[K: ClassTag, V: ClassTag](rs: Traversable[RDD[(K, V)]]) {
-    def combineValues[R: ClassTag](f: Traversable[V] => R): RDD[(K, R)] = combineValues(f, None)
-    def combineValues[R: ClassTag](f: Traversable[V] => R, partitioner: Option[Partitioner]): RDD[(K, R)] =
+    def combineValues[R: ClassTag](f: Traversable[V] => R, partitioner: Option[Partitioner] = None): RDD[(K, R)] =
       rs.head.combineValues(rs.tail, partitioner)(f)
   }
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/AddTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/AddTileRDDMethods.scala
@@ -35,13 +35,10 @@ trait AddTileRDDMethods[K] extends TileRDDMethods[K] {
 
   /** Add the values of each cell in each raster. */
   def +(other: Self): Self = localAdd(other, None)
-  def +(other: Self, partitioner: Option[Partitioner]): Self = localAdd(other, partitioner)
 
   def localAdd(others: Traversable[Self]): Self = localAdd(others, None)
   def localAdd(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
     self.combineValues(others, partitioner) { Add.apply }
 
   def +(others: Traversable[Self]): Self = localAdd(others, None)
-  def +(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
-    localAdd(others, partitioner)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/AndTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/AndTileRDDMethods.scala
@@ -23,8 +23,7 @@ trait AndTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner){ And.apply }
 
   /** And the values of each cell in each raster. */
-  def &(rs: RasterRDD[K]): Self = &(rs, None)
-  def &(rs: RasterRDD[K], partitioner: Option[Partitioner]): Self = localAnd(rs, partitioner)
+  def &(rs: RasterRDD[K]): Self = localAnd(rs, None)
 
   /** And the values of each cell in each raster.  */
   def localAnd(others: Traversable[Self]): Self = localAnd(others, None)
@@ -32,7 +31,5 @@ trait AndTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(others, partitioner){ And.apply }
 
   /** And the values of each cell in each raster. */
-  def &(others: Traversable[Self]): Self = &(others, None)
-  def &(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
-    localAnd(others, partitioner)
+  def &(others: Traversable[Self]): Self = localAnd(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/DivideTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/DivideTileRDDMethods.scala
@@ -41,15 +41,11 @@ trait DivideTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner)(Divide.apply)
 
   /** Divide the values of each cell in each raster. */
-  def /(other: Self): Self = /(other, None)
-  def /(other: Self, partitioner: Option[Partitioner]): Self =
-    localDivide(other, partitioner)
+  def /(other: Self): Self = localDivide(other, None)
 
   def localDivide(others: Traversable[Self]): Self = localDivide(others, None)
   def localDivide(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
     self.combineValues(others, partitioner)(Divide.apply)
 
-  def /(others: Traversable[Self]): Self = /(others, None)
-  def /(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
-    localDivide(others, partitioner)
+  def /(others: Traversable[Self]): Self = localDivide(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/EqualTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/EqualTileRDDMethods.scala
@@ -28,7 +28,6 @@ trait EqualTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell value of the input raster is equal to the provided
     * raster, else 0.
     */
-  def localEqual(other: Self): Self = localEqual(other, None)
-  def localEqual(other: Self, partitioner: Option[Partitioner]): Self =
+  def localEqual(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(Equal.apply)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/GreaterOrEqualTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/GreaterOrEqualTileRDDMethods.scala
@@ -72,14 +72,12 @@ trait GreaterOrEqualTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are greater than or equal
     * to the next raster, else 0.
     */
-  def localGreaterOrEqual(other: Self): Self = localGreaterOrEqual(other, None)
-  def localGreaterOrEqual(other: Self, partitioner: Option[Partitioner]): Self =
+  def localGreaterOrEqual(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(GreaterOrEqual.apply)
   /**
     * Returns a RasterRDD with data of TypeBit, where cell values equal 1 if
     * the corresponding cell valued of the rasters are greater than or equal
     * to the next raster, else 0.
     */
-  def >=(other: Self): Self = >=(other, None)
-  def >=(other: Self, partitioner: Option[Partitioner]): Self = localGreaterOrEqual(other, partitioner)
+  def >=(other: Self): Self = localGreaterOrEqual(other)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/GreaterTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/GreaterTileRDDMethods.scala
@@ -76,8 +76,7 @@ trait GreaterTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are greater than the next
     * raster, else 0.
     */
-  def localGreater(other: Self): Self = localGreater(other, None)
-  def localGreater(other: Self, partitioner: Option[Partitioner]): Self =
+  def localGreater(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(Greater.apply)
 
   /**
@@ -85,6 +84,5 @@ trait GreaterTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the raster are greater than the next
     * raster, else 0.
     */
-  def >(other: Self): Self = localGreater(other, None)
-  def >(other: Self, partitioner: Option[Partitioner]): Self = localGreater(other, partitioner)
+  def >(other: Self): Self = localGreater(other)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/LessOrEqualTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/LessOrEqualTileRDDMethods.scala
@@ -64,8 +64,7 @@ trait LessOrEqualTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are less than or equal to the
     * next raster, else 0.
     */
-  def localLessOrEqual(other: Self): Self = localLessOrEqual(other, None)
-  def localLessOrEqual(other: Self, partitioner: Option[Partitioner]): Self =
+  def localLessOrEqual(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(LessOrEqual.apply)
 
   /**
@@ -73,6 +72,5 @@ trait LessOrEqualTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are less than or equal to the
     * next raster, else 0.
     */
-  def <=(other: Self): Self = <=(other, None)
-  def <=(other: Self, partitioner: Option[Partitioner]): Self = localLessOrEqual(other, partitioner)
+  def <=(other: Self): Self = localLessOrEqual(other)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/LessTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/LessTileRDDMethods.scala
@@ -73,8 +73,7 @@ trait LessTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are less than the next
     * raster, else 0.
     */
-  def localLess(other: Self): Self = localLess(other, None)
-  def localLess(other: Self, partitioner: Option[Partitioner]): Self =
+  def localLess(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(Less.apply)
 
   /**
@@ -82,6 +81,5 @@ trait LessTileRDDMethods[K] extends TileRDDMethods[K] {
     * the corresponding cell valued of the rasters are less than the next
     * raster, else 0.
     */
-  def <(other: Self): Self = localLess(other, None)
-  def <(other: Self, partitioner: Option[Partitioner]): Self = localLess(other, partitioner)
+  def <(other: Self, partitioner: Option[Partitioner] = None): Self = localLess(other, partitioner)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/LocalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/LocalTileRDDMethods.scala
@@ -36,8 +36,7 @@ trait LocalTileRDDMethods[K] extends TileRDDMethods[K]
     * For example, if *all* cells in the second raster are set to the readMask value,
     * the output raster will be empty -- all values set to NODATA.
     */
-  def localMask(other: Self, readMask: Int, writeMask: Int): Self = localMask(other, readMask, writeMask, None)
-  def localMask(other: Self, readMask: Int, writeMask: Int, partitioner: Option[Partitioner]): Self =
+  def localMask(other: Self, readMask: Int, writeMask: Int, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner) {
       case (r1, r2) => Mask(r1, r2, readMask, writeMask)
     }
@@ -50,9 +49,7 @@ trait LocalTileRDDMethods[K] extends TileRDDMethods[K]
     * For example, if *all* cells in the second raster are set to the readMask value,
     * the output raster will be identical to the first raster.
     */
-  def localInverseMask(other: Self, readMask: Int, writeMask: Int): Self =
-    localInverseMask(other, readMask, writeMask, None)
-  def localInverseMask(other: Self, readMask: Int, writeMask: Int, partitioner: Option[Partitioner]): Self =
+  def localInverseMask(other: Self, readMask: Int, writeMask: Int, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner) {
       case (r1, r2) => InverseMask(r1, r2, readMask, writeMask)
     }
@@ -134,8 +131,7 @@ trait LocalTileRDDMethods[K] extends TileRDDMethods[K]
     *
     *  @info               A double raster is always returned.
     */
-  def localAtan2(other: Self): Self = localAtan2(other, None)
-  def localAtan2(other: Self, partitioner: Option[Partitioner]): Self =
+  def localAtan2(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(Atan2.apply)
 
   /**

--- a/spark/src/main/scala/geotrellis/spark/op/local/MultiplyTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/MultiplyTileRDDMethods.scala
@@ -49,8 +49,7 @@ trait MultiplyTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner)(Multiply.apply)
 
   /** Multiply the values of each cell in each raster. */
-  def *(other: Self): Self = *(other, None)
-  def *(other: Self, partitioner: Option[Partitioner]): Self = localMultiply(other, partitioner)
+  def *(other: Self): Self = localMultiply(other, None)
 
   /** Multiply the values of each cell in each raster. */
   def localMultiply(others: Traversable[Self]): Self = localMultiply(others, None)
@@ -58,6 +57,5 @@ trait MultiplyTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(others, partitioner)(Multiply.apply)
 
   /** Multiply the values of each cell in each raster. */
-  def *(others: Traversable[Self]): Self = *(others, None)
-  def *(others: Traversable[Self], partitioner: Option[Partitioner]): Self = localMultiply(others, partitioner)
+  def *(others: Traversable[Self]): Self = localMultiply(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/OrTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/OrTileRDDMethods.scala
@@ -23,8 +23,7 @@ trait OrTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner)(Or.apply)
 
   /** Or the values of each cell in each raster. */
-  def |(r: Self): Self = |(r, None)
-  def |(r: Self, partitioner: Option[Partitioner]): Self = localOr(r, partitioner)
+  def |(r: Self): Self = localOr(r, None)
 
   /** Or the values of each cell in each raster.  */
   def localOr(others: Traversable[Self]): Self = localOr(others, None)
@@ -32,6 +31,5 @@ trait OrTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(others, partitioner)(Or.apply)
 
   /** Or the values of each cell in each raster. */
-  def |(others: Traversable[Self]): Self = |(others, None)
-  def |(others: Traversable[Self], partitioner: Option[Partitioner]): Self = localOr(others, partitioner)
+  def |(others: Traversable[Self]): Self = localOr(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/PowTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/PowTileRDDMethods.scala
@@ -40,14 +40,12 @@ trait PowTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner)(Pow.apply)
 
   /** Pow the values of each cell in each raster. */
-  def **(other: Self): Self = **(other, None)
-  def **(other: Self, partitioner: Option[Partitioner]): Self = localPow(other, partitioner)
+  def **(other: Self): Self = localPow(other, None)
 
   /** Pow the values of each cell in each raster. */
   def localPow(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
     self.combineValues(others, partitioner)(Pow.apply)
 
   /** Pow the values of each cell in each raster. */
-  def **(others: Traversable[Self]): Self = **(others, None)
-  def **(others: Traversable[Self], partitioner: Option[Partitioner]): Self = localPow(others, partitioner)
+  def **(others: Traversable[Self]): Self = localPow(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/SubtractTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/SubtractTileRDDMethods.scala
@@ -58,7 +58,6 @@ trait SubtractTileRDDMethods[K] extends TileRDDMethods[K] {
 
   /** Subtract the values of each cell in each raster. */
   def -(other: Self): Self = localSubtract(other, None)
-  def -(other: Self, partitioner: Option[Partitioner]): Self = localSubtract(other, partitioner)
 
   /** Subtract the values of each cell in each raster. */
   def localSubtract(others: Traversable[Self]): Self = localSubtract(others, None)
@@ -67,5 +66,4 @@ trait SubtractTileRDDMethods[K] extends TileRDDMethods[K] {
 
   /** Subtract the values of each cell in each raster. */
   def -(others: Traversable[Self]): Self = localSubtract(others, None)
-  def -(others: Traversable[Self], partitioner: Option[Partitioner]): Self = localSubtract(others, partitioner)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/UnequalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/UnequalTileRDDMethods.scala
@@ -55,14 +55,12 @@ trait UnequalTileRDDMethods[K] extends TileRDDMethods[K] {
    * Returns a Tile with data of TypeBit, where cell values equal 1 if
    * the corresponding cell valued of the rasters are not equal, else 0.
    */
-  def localUnequal(other: Self): Self = localUnequal(other, None)
-  def localUnequal(other: Self, partitioner: Option[Partitioner]): Self =
+  def localUnequal(other: Self, partitioner: Option[Partitioner] = None): Self =
     self.combineValues(other, partitioner)(Unequal.apply)
 
   /**
    * Returns a Tile with data of TypeBit, where cell values equal 1 if
    * the corresponding cell valued of the raster are not equal, else 0.
    */
-  def !==(other: Self): Self = !==(other, None)
-  def !==(other: Self, partitioner: Option[Partitioner]): Self = localUnequal(other, partitioner)
+  def !==(other: Self): Self = localUnequal(other)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/XorTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/XorTileRDDMethods.scala
@@ -23,15 +23,13 @@ trait XorTileRDDMethods[K] extends TileRDDMethods[K] {
     self.combineValues(other, partitioner)(Xor.apply)
 
   /** Xor the values of each cell in each raster. */
-  def ^(r: RasterRDD[K]): Self = ^(r, None)
-  def ^(r: RasterRDD[K], partitioner: Option[Partitioner]): Self = localXor(r, partitioner)
-
+  def ^(r: RasterRDD[K]): Self = localXor(r, None)
+  
   /** Xor the values of each cell in each raster. */
   def localXor(others: Traversable[Self]): Self = localXor(others, None)
   def localXor(others: Traversable[Self], partitioner: Option[Partitioner]): Self =
     self.combineValues(others, partitioner)(Xor.apply)
 
   /** Xor the values of each cell in each raster. */
-  def ^(others: Traversable[Self]): Self = ^(others, None)
-  def ^(others: Traversable[Self], partitioner: Option[Partitioner]): Self = localXor(others, partitioner)
+  def ^(others: Traversable[Self]): Self = localXor(others, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/op/local/temporal/LocalTemporalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/local/temporal/LocalTemporalTileRDDMethods.scala
@@ -28,56 +28,32 @@ trait LocalTemporalTileRDDMethods[K] extends TileRDDMethods[K] {
     windowSize: Int,
     unit: Int,
     start: DateTime,
-    end: DateTime): Self = temporalMin(windowSize, unit, start, end, None)
-
-  def temporalMin(
-    windowSize: Int,
-    unit: Int,
-    start: DateTime,
     end: DateTime,
-    partitioner: Option[Partitioner]): Self =
+    partitioner: Option[Partitioner] = None): Self =
     aggregateWithTemporalWindow(windowSize, unit, start, end, partitioner)(minReduceOp)
 
   def temporalMax(
     windowSize: Int,
     unit: Int,
     start: DateTime,
-    end: DateTime): Self = temporalMax(windowSize, unit, start, end, None)
-
-  def temporalMax(
-    windowSize: Int,
-    unit: Int,
-    start: DateTime,
     end: DateTime,
-    partitioner: Option[Partitioner]): Self =
+    partitioner: Option[Partitioner] = None): Self =
     aggregateWithTemporalWindow(windowSize, unit, start, end, partitioner)(maxReduceOp)
 
   def temporalMean(
     windowSize: Int,
     unit: Int,
     start: DateTime,
-    end: DateTime): Self = temporalMean(windowSize, unit, start, end, None)
-
-  def temporalMean(
-    windowSize: Int,
-    unit: Int,
-    start: DateTime,
     end: DateTime,
-    partitioner: Option[Partitioner]): Self =
+    partitioner: Option[Partitioner] = None): Self =
     aggregateWithTemporalWindow(windowSize, unit, start, end, partitioner)(meanReduceOp)
 
   def temporalVariance(
     windowSize: Int,
     unit: Int,
     start: DateTime,
-    end: DateTime): Self = temporalVariance(windowSize, unit, start, end, None)
-
-  def temporalVariance(
-    windowSize: Int,
-    unit: Int,
-    start: DateTime,
     end: DateTime,
-    partitioner: Option[Partitioner]): Self =
+    partitioner: Option[Partitioner] = None): Self =
     aggregateWithTemporalWindow(windowSize, unit, start, end, partitioner)(varianceReduceOp)
 
   private def aggregateWithTemporalWindow(
@@ -85,7 +61,7 @@ trait LocalTemporalTileRDDMethods[K] extends TileRDDMethods[K] {
     unit: Int,
     start: DateTime,
     end: DateTime,
-    partitioner: Option[Partitioner])(
+    partitioner: Option[Partitioner] = None)(
     reduceOp: Traversable[Tile] => Tile
   ): Self = {
     val rdd =

--- a/spark/src/main/scala/geotrellis/spark/op/stats/StatsTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/stats/StatsTileRDDMethods.scala
@@ -12,8 +12,7 @@ import org.apache.spark.rdd.RDD
 
 trait StatsTileRDDMethods[K] extends TileRDDMethods[K] {
 
-  def averageByKey: RDD[(K, Tile)] = averageByKey(None)
-  def averageByKey(partitioner: Option[Partitioner]): RDD[(K, Tile)] = {
+  def averageByKey(partitioner: Option[Partitioner] = None): RDD[(K, Tile)] = {
     val createCombiner = (tile: Tile) => tile -> 1
     val mergeValue = (tup: (Tile, Int), tile2: Tile) => {
       val (tile1, count) = tup

--- a/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
+++ b/spark/src/main/scala/geotrellis/spark/op/zonal/ZonalTileRDDMethods.scala
@@ -27,15 +27,13 @@ trait ZonalTileRDDMethods[K] extends TileRDDMethods[K] {
     res
   }
 
-  def zonalHistogram(zonesRasterRDD: Self): Map[Int, Histogram] = zonalHistogram(zonesRasterRDD, None)
-  def zonalHistogram(zonesRasterRDD: Self, partitioner: Option[Partitioner]): Map[Int, Histogram] =
+  def zonalHistogram(zonesRasterRDD: Self, partitioner: Option[Partitioner] = None): Map[Int, Histogram] =
     partitioner
       .fold(self.join(zonesRasterRDD))(self.join(zonesRasterRDD, _))
       .map((t: (K, (Tile, Tile))) => ZonalHistogram(t._2._1, t._2._2))
       .fold(Map[Int, Histogram]())(mergeMaps)
 
-  def zonalPercentage(zonesRasterRDD: Self): RDD[(K, Tile)] = zonalPercentage(zonesRasterRDD, None)
-  def zonalPercentage(zonesRasterRDD: Self, partitioner: Option[Partitioner]): RDD[(K, Tile)] = {
+  def zonalPercentage(zonesRasterRDD: Self, partitioner: Option[Partitioner] = None): RDD[(K, Tile)] = {
     val sc = self.sparkContext
     val zoneHistogramMap = zonalHistogram(zonesRasterRDD, partitioner)
     val zoneSumMap = zoneHistogramMap.map { case (k, v) => k -> v.getTotalCount }


### PR DESCRIPTION
Mostly removing partitioner from symbolic ops like `+` because they must be used in infix position. If user needs to specify a partitioner, they need to use explicit names like `localAdd`.

Also tried to use default values where possible but mostly it's not an option for operations that can have right hand side as either primitive or RDD values.