### PR TITLE
Use environment vars to configure Terraform

### DIFF
--- a/scripts/emr/Makefile
+++ b/scripts/emr/Makefile
@@ -10,7 +10,11 @@ ifndef CLUSTER_ID
 CLUSTER_ID=$(shell cat terraform/terraform.tfstate | jq -r ".modules[].outputs.emrID.value")
 endif
 ifndef KEY_PAIR_FILE
+ifndef TF_VAR_pem_path
 KEY_PAIR_FILE=$(shell cat terraform/variables.tf.json | jq -r ".variable.pem_path.default")
+else
+KEY_PAIR_FILE=$TF_VAR_pem_path
+endif
 endif
 
 terraform-init:

--- a/scripts/emr/README.md
+++ b/scripts/emr/README.md
@@ -42,10 +42,7 @@ with very little config, and it also helps us keep track of their state.
 
 Providers used to be built-in to Terraform. As of a recent version, they've been
 removed and are instead provided by "plugins" that are usually automatically installable.
-For instance, we will use the `terraform-provider-aws` plugin. We can't use the automatically
-installed one right now, however, because we need a side-feature that only exists in some guy's
-PR. It will be merged soon, since contributors have responded to the PR and are just waiting
-for a few more additions.
+For instance, we will use the `terraform-provider-aws` plugin.
 
 ### Installing Terraform Core
 
@@ -63,6 +60,7 @@ and see something like:
 ```
 Terraform v0.10.0-dev (870617d22df3f9245889a75c63119b94057c6e48+CHANGES)
 ```
+then you have a successful installation.
 
 ### Installing the AWS Provider Plugin
 
@@ -73,13 +71,25 @@ visible to Terraform.
 
 ## Running
 
-Run cluster and upload assembly on EMR master node:
+Create a cluster and upload assembly on EMR master node:
 
 ```bash
 make terraform-init && \
 make create-cluster && \
 make upload-assembly
 ```
+
+It will be necessary to provide your AWS credentials to the Terraform script.
+Terraform will prompt for the access key, the secret key, and the PEM path for
+the current account.  You may enter these explicitly, or you may choose to set
+environment variables to avoid having to repeatedly fill out the prompts.  If
+`TF_VAR_access_key`, `TF_VAR_secret_key`, and `TF_VAR_pem_path`, these will be
+discovered by the Terraform script and you will not be prompted at startup.
+The same mechanism can be used to set other variables.  `TF_VAR_spot_price`
+and `TF_VAR_worker_count` are useful values.
+
+Note: long startup times (greater than 5 or 6 minutes) probably indicates that
+you have chosen a spot price that is too low.
 
 Make proxy and access Zeppelin though UI:
 

--- a/scripts/emr/terraform/emr-spark.tf
+++ b/scripts/emr/terraform/emr-spark.tf
@@ -23,7 +23,7 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   # MASTER group must have an instance_count of 1.
   # `xlarge` seems to be the smallest type they'll allow (large didn't work).
   instance_group {
-    bid_price      = "0.05"
+    bid_price      = "${var.spot_price}"
     instance_count = 1
     instance_role  = "MASTER"
     instance_type  = "m3.xlarge"
@@ -31,8 +31,8 @@ resource "aws_emr_cluster" "emr-spark-cluster" {
   }
 
   instance_group {
-    bid_price      = "0.05"
-    instance_count = 2
+    bid_price      = "${var.spot_price}"
+    instance_count = "${var.worker_count}"
     instance_role  = "CORE"
     instance_type  = "m3.xlarge"
     name           = "EmrGeoTrellisZeppelin-CoreGroup"

--- a/scripts/emr/terraform/variables.tf.json
+++ b/scripts/emr/terraform/variables.tf.json
@@ -1,20 +1,17 @@
 { 
   "variable": {
     "access_key": { 
-        "default": "",
         "description": "From your `~/.aws/credentials"
     },
     "secret_key": {
-        "default": "",
         "description": "From your `~/.aws/credentials"
+    },
+    "pem_path": {
+        "description": "Path to your EC2 secret key"
     },
     "region": {
         "default": "us-east-1",
         "description": "Can be overridden if necessary"
-    },
-    "pem_path": {
-        "default": "",
-        "description": "Path to your EC2 secret key"
     },
     "key_name": {
         "default": "geotrellis-emr",
@@ -23,6 +20,14 @@
     "s3_uri": {
         "default": "s3://geotrellis-test/terraform-logs",
         "description": "Location to dump EMR logs"
+    },
+    "spot_price": {
+        "default": "0.05",
+        "description": "The bid price for each EMR spot instance"
+    },
+    "worker_count": {
+        "default": "2",
+        "description": "The number of worker nodes to provision"
     }
   }
 }


### PR DESCRIPTION
Supplying state to terraform via `TF_VAR_xxxxx` environment variables removes the need to edit the `variables.tf.json` file.  This behavior should be encouraged so that the terraform scripts can be used without interfering with git.

Signed-off-by: jpolchlo <jpolchlopek@azavea.com>